### PR TITLE
Prevent memory leak

### DIFF
--- a/MONActivityIndicatorView/MONActivityIndicatorView.h
+++ b/MONActivityIndicatorView/MONActivityIndicatorView.h
@@ -26,7 +26,7 @@
 @property (readwrite, nonatomic) CGFloat duration;
 
 /** The assigned delegate */
-@property (strong, nonatomic) id<MONActivityIndicatorViewDelegate> delegate;
+@property (weak, nonatomic) id<MONActivityIndicatorViewDelegate> delegate;
 
 
 /**


### PR DESCRIPTION
Hi @mownier ,
Great component. I am using it in a project and noticed a memory leak fixed in this pull request.
By having the delegate property to strong, you are preventing the delegate from being released from memory. I can confirm this by noticing that my VC that owns the view and is it's delegate is never being dealloc'd.

By making the delegate property a weak reference, MonActivityIndicatorView allows the delegate object to be dealloc'd as expected. This is safe since the delegate is always being checked for a non-nil value before being used.

Best,
Glenn
