### PR TITLE
Add initWithParentView

### DIFF
--- a/MONActivityIndicatorViewDemo/MONActivityIndicatorViewDemo/Source/Controllers/MONViewController.m
+++ b/MONActivityIndicatorViewDemo/MONActivityIndicatorViewDemo/Source/Controllers/MONViewController.m
@@ -21,39 +21,15 @@
 - (void)viewDidLoad {
     [super viewDidLoad];
     
-    MONActivityIndicatorView *indicatorView = [[MONActivityIndicatorView alloc] init];
+    MONActivityIndicatorView *indicatorView = [[MONActivityIndicatorView alloc] initWithParentView:self.view];
     indicatorView.delegate = self;
     indicatorView.numberOfCircles = 3;
     indicatorView.radius = 20;
     indicatorView.internalSpacing = 3;
     [indicatorView startAnimating];
-    
-    [self.view addSubview:indicatorView];
-    [self placeAtTheCenterWithView:indicatorView];
-    
+        
     [NSTimer scheduledTimerWithTimeInterval:7 target:indicatorView selector:@selector(stopAnimating) userInfo:nil repeats:NO];
     [NSTimer scheduledTimerWithTimeInterval:9 target:indicatorView selector:@selector(startAnimating) userInfo:nil repeats:NO];
-}
-
-#pragma mark -
-#pragma mark - Centering Indicator View
-
-- (void)placeAtTheCenterWithView:(UIView *)view {
-    [self.view addConstraint:[NSLayoutConstraint constraintWithItem:view
-                                                          attribute:NSLayoutAttributeCenterX
-                                                          relatedBy:NSLayoutRelationEqual
-                                                             toItem:self.view
-                                                          attribute:NSLayoutAttributeCenterX
-                                                         multiplier:1.0f
-                                                           constant:0.0f]];
-    
-    [self.view addConstraint:[NSLayoutConstraint constraintWithItem:view
-                                                          attribute:NSLayoutAttributeCenterY
-                                                          relatedBy:NSLayoutRelationEqual
-                                                             toItem:self.view
-                                                          attribute:NSLayoutAttributeCenterY
-                                                         multiplier:1.0f
-                                                           constant:0.0f]];
 }
 
 #pragma mark -

--- a/MONActivityIndicatorViewDemo/MONActivityIndicatorViewDemo/Source/Views/MONActivityIndicatorView/MONActivityIndicatorView.h
+++ b/MONActivityIndicatorViewDemo/MONActivityIndicatorViewDemo/Source/Views/MONActivityIndicatorView/MONActivityIndicatorView.h
@@ -30,6 +30,11 @@
 
 
 /**
+ Init with parent view and place activity indicator at the center of parent view
+ */
+- (id)initWithParentView:(UIView*) parentView;
+
+/**
  Starts the animation of the activity indicator.
  */
 - (void)startAnimating;

--- a/MONActivityIndicatorViewDemo/MONActivityIndicatorViewDemo/Source/Views/MONActivityIndicatorView/MONActivityIndicatorView.m
+++ b/MONActivityIndicatorViewDemo/MONActivityIndicatorViewDemo/Source/Views/MONActivityIndicatorView/MONActivityIndicatorView.m
@@ -78,6 +78,16 @@
     return self;
 }
 
+- (id)initWithParentView:(UIView*) parentView {
+    self = [super initWithFrame:CGRectZero];
+    if (self) {
+        [self setupDefaults];
+        [parentView addSubview:self];
+        [self placeAtTheCenterOfView:parentView];
+    }
+    return self;
+}
+
 #pragma mark -
 #pragma mark - Intrinsic Content Size
 
@@ -143,6 +153,27 @@
     [self.subviews enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
         [obj removeFromSuperview];
     }];
+}
+
+#pragma mark -
+#pragma mark - Centering Indicator View
+
+- (void)placeAtTheCenterOfView:(UIView *) parentView {
+    [parentView addConstraint:[NSLayoutConstraint constraintWithItem:self
+                                                          attribute:NSLayoutAttributeCenterX
+                                                          relatedBy:NSLayoutRelationEqual
+                                                             toItem:parentView
+                                                          attribute:NSLayoutAttributeCenterX
+                                                         multiplier:1.0f
+                                                           constant:0.0f]];
+    
+    [parentView addConstraint:[NSLayoutConstraint constraintWithItem:self
+                                                          attribute:NSLayoutAttributeCenterY
+                                                          relatedBy:NSLayoutRelationEqual
+                                                             toItem:parentView
+                                                          attribute:NSLayoutAttributeCenterY
+                                                         multiplier:1.0f
+                                                           constant:0.0f]];
 }
 
 #pragma mark -


### PR DESCRIPTION
Mostly indicator is placed at the center of its parent view. Adding
placeAtTheCenterWithView to the MONActivityIndicatorView.m can make the
view controller lighter. Demo is also changed to show the usage of the new
method. 

This is my first PR. Sorry for any incorrect operation.
Thanks. :)